### PR TITLE
Modularize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ name = "httpstat"
 version = "0.1.0"
 
 [lib]
-name = "curl"
-path = "src/curl/lib.rs"
+name = "httpstat"
+path = "src/lib.rs"
 
 [[bin]]
 name = "httpstat"

--- a/README.md
+++ b/README.md
@@ -11,8 +11,24 @@ $ cargo install --git https://github.com/woxtu/rust-httpstat
 ```
 
 ## Usage
+as command-line tool:
+```
+$ httpstat https://www.rust-lang.org/
+```
 
-Work in progress.
+as package:
+```
+extern crate httpstat;
+
+fn main() {
+    let url = "https://www.rust-lang.org/";
+    match httpstat::request(url) {
+        Ok((_resp, time)) => println!("{:?}", time),
+        Err(e) => println!("fail httpstat request: {}", e),
+    }
+}
+```
+
 
 ## License
 

--- a/src/curl/mod.rs
+++ b/src/curl/mod.rs
@@ -8,6 +8,7 @@ pub struct Response {
   pub body: String,
 }
 
+#[derive(Debug)]
 pub struct Time {
   pub namelookup: f64,
   pub connect: f64,
@@ -16,4 +17,4 @@ pub struct Time {
   pub total: f64,
 }
 
-pub use easy::Easy;
+pub use self::easy::Easy;

--- a/src/httpstat/app.rs
+++ b/src/httpstat/app.rs
@@ -3,7 +3,6 @@ use std::error::Error;
 use std::fs::File;
 use std::io::Write;
 use clap::ArgMatches;
-use curl;
 use rand;
 use rand::Rng;
 
@@ -12,7 +11,7 @@ use super::{Body, Header, Time};
 pub fn run(args: &ArgMatches) -> Result<(), Box<Error>> {
   let url = args.value_of("url").unwrap();
 
-  let client = try!(curl::easy::Easy::new());
+  let client = try!(::httpstat::curl::easy::Easy::new());
   try!(client.set_url(url));
 
   let response = try!(client.perform());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,33 @@ extern crate rand;
 
 pub mod httpstat;
 pub mod curl;
+
+pub fn request(url: &str) -> Result<(curl::Response, curl::Time), String> {
+    let client = curl::easy::Easy::new();
+    match client {
+        Err(e) => return Err(format!("{}", e)),
+        _ => {},
+    }
+    let client = client.unwrap();
+
+    match client.set_url(url) {
+        Err(e) => return Err(format!("{}", e)),
+        _ => {},
+    }
+
+    let response = client.perform();
+    match response {
+        Err(e) => return Err(format!("{}", e)),
+        _ => {},
+    }
+    let response = response.unwrap();
+
+    let time = client.get_time();
+    match time {
+        Err(e) => return Err(format!("{}", e)),
+        _ => {}
+    }
+    let time = time.unwrap();
+
+    Ok((response, time))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,8 @@
+extern crate regex;
+extern crate curl_sys;
+extern crate libc;
+extern crate clap;
+extern crate rand;
+
+pub mod httpstat;
+pub mod curl;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,10 @@
 extern crate clap;
-extern crate curl;
+extern crate httpstat;
 extern crate rand;
 extern crate regex;
 
 use std::io::prelude::*;
 use clap::App;
-
-mod httpstat;
 
 fn main() {
   let args = App::new("httpstat")
@@ -17,7 +15,7 @@ fn main() {
     )
     .get_matches();
 
-  match httpstat::app::run(&args) {
+  match httpstat::httpstat::app::run(&args) {
     Ok(()) => (),
     Err(error) => {
       let _ = write!(std::io::stderr(), "{}", error.to_string());


### PR DESCRIPTION
### motivation
`rust-httpstat` is cool tool 👍 
I want to use this tool as a module.

### change summary
* change to using as module
* rename crate name to `httpstat`
* add `httpstat::request` function for easy use 

Thanks